### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,21 +6,21 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-A4988				KEYWORD1	A4988
+A4988	KEYWORD1	A4988
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-enable				KEYWORD2
-disable				KEYWORD2
-doStep				KEYWORD2
-isEnabled			KEYWORD2
-up					KEYWORD2
-down				KEYWORD2
+enable	KEYWORD2
+disable	KEYWORD2
+doStep	KEYWORD2
+isEnabled	KEYWORD2
+up	KEYWORD2
+down	KEYWORD2
 setStepsPerRound	KEYWORD2
-setStepDelay		KEYWORD2
-setRPM				KEYWORD2
+setStepDelay	KEYWORD2
+setRPM	KEYWORD2
 
 
 
@@ -28,10 +28,10 @@ setRPM				KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-NONE				LITERAL1
-FULL				LITERAL1
-HALF				LITERAL1
-QUARTER				LITERAL1
-EIGTHTH				LITERAL1
-SIXTEENTH			LITERAL1
+NONE	LITERAL1
+FULL	LITERAL1
+HALF	LITERAL1
+QUARTER	LITERAL1
+EIGTHTH	LITERAL1
+SIXTEENTH	LITERAL1
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords